### PR TITLE
Correção dos mapas da estruturas do ideciclo

### DIFF
--- a/components/IdecicloTable.tsx
+++ b/components/IdecicloTable.tsx
@@ -115,7 +115,9 @@ const IdecicloTable = ({ data }) => {
         accessor: "logradouro",
         Cell: ({ row }) => (
             <Link href={`ideciclo/${row.original.id}`} key={row.original.id}>
-                <a className="text-ameciclo">{row.original.logradouro}</a>
+                {row.original.cidade == 1 ? 
+                (<a className="text-ameciclo">{row.original.logradouro}</a>) :
+                (<>{row.original.logradouro}</>)}
             </Link>
         ),
         Filter: ColumnFilter,

--- a/pages/ideciclo.tsx
+++ b/pages/ideciclo.tsx
@@ -130,6 +130,7 @@ const layers = {
       city_structures.forEach(d => {
         segs.push(
           { id: d.id,
+            cidade: d.city_id,
             logradouro: d.street,
             tipologia: d.typology,
             comprimento: d.reviews[d.reviews.length-1].length/1000,

--- a/pages/ideciclo/[ideciclo].tsx
+++ b/pages/ideciclo/[ideciclo].tsx
@@ -71,23 +71,30 @@ function get_map_data(structure) {
     );
   });
 
+  if(geoJsonMap.features[0] == undefined){
+    geoJsonMap.features = map.features
+  }
+
   return geoJsonMap;
 }
 
 const Ideciclo = ({ structure, forms }) => {
   let info = rates_organization(structure, forms);
-  info.map = get_map_data(structure);
+
+  info.map = get_map_data(structure)
 
   const [minLng, minLat, maxLng, maxLat] = bbox(info.map);
+
   const vp = new WebMercatorViewport({
     width: 400,
     height: 600,
-    longitude: -122.45,
-    latitude: 37.78,
-    zoom: 12,
+    longitude: -48,
+    latitude: -10,
+    zoom: 1,
     pitch: 30,
     bearing: 15,
   });
+
   const { longitude, latitude, zoom } = vp.fitBounds(
     [
       [minLng, minLat],
@@ -310,8 +317,8 @@ const Ideciclo = ({ structure, forms }) => {
                                 "" +
                                 (inner_param.different
                                   ? inner_param.bigger
-                                    ? "🔺"
-                                    : "🔻"
+                                    ? ""
+                                    : ""
                                   : "")
                               : "N/A"}
                           </h3>
@@ -345,9 +352,9 @@ const Ideciclo = ({ structure, forms }) => {
 export async function getStaticPaths() {
   const res = await fetch(`${server}/structures`);
   const allstructs = await res.json();
-
+  const rec_structs = allstructs.filter(s => s.city_id === 1)
   // Get the paths we want to pre-render based on posts
-  const paths = allstructs.map((s) => ({
+  const paths = rec_structs.map((s) => ({
     params: { ideciclo: s.id },
   }));
 


### PR DESCRIPTION
Só está gerando mapas para o Recife, assim como páginas internas. Só tem link para páginas do Recife. Mostra a nota de todas.